### PR TITLE
refactor(auth): move token refresh logic into response interceptor and remove refreshAccess helpers

### DIFF
--- a/tarot-planning/src/features/tarotDiaryAPI.js
+++ b/tarot-planning/src/features/tarotDiaryAPI.js
@@ -1,5 +1,4 @@
-import router from '@/router'
-import { apiClient, refreshClient } from '@/lib/http'
+import { apiClient } from '@/lib/http'
 
 export default {
   async GET(url) {
@@ -13,22 +12,5 @@ export default {
   async PUT(url, data) {
     const res = await apiClient.put(url, data)
     return res.data
-  },
-  async refreshAccess(oldToken) {
-    try {
-      const { data } = await refreshClient.post(
-        '/api/auth/refresh',
-        {},
-        {
-          headers: { Authorization: `Bearer ${oldToken}` },
-        },
-      )
-      localStorage.setItem('accessToken', data.token)
-      return data.token
-    } catch (e) {
-      localStorage.removeItem('accessToken')
-      router.replace({ name: 'login' })
-      throw e
-    }
   },
 }

--- a/tarot-planning/src/lib/http.js
+++ b/tarot-planning/src/lib/http.js
@@ -14,7 +14,6 @@ export const apiClient = axios.create({
 apiClient.interceptors.request.use(
   async (config) => {
     const authStore = useAuthStore()
-    await authStore.refreshIfNeeded()
     if (authStore.token) {
       config.headers.Authorization = `Bearer ${authStore.token}`
     }
@@ -25,10 +24,42 @@ apiClient.interceptors.request.use(
   },
 )
 
-export const refreshClient = axios.create({
-  baseURL: API_URL,
-  headers: {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
+apiClient.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    //當請求失敗時攔截response
+    const authStore = useAuthStore()
+    const original = err.config
+
+    //如果本來是發refresh但失敗，就強制登出
+    if (original.url?.includes('/api/auth/refresh')) {
+      await authStore.logout(true)
+      return Promise.reject(err)
+    }
+
+    //錯誤回401可能代表token到期，嘗試發refresh
+    if (err.response?.status === 401 && !original.__isRetryRequest) {
+      //在原請求標記以嘗試發過refresh，下次發原請求就不會再嘗試refresh
+      original.__isRetryRequest = true
+
+      try {
+        const { data } = await apiClient.post(
+          '/api/auth/refresh',
+          {},
+          {
+            headers: { Authorization: `Bearer ${authStore.token}` },
+          },
+        )
+        authStore.setToken(data.token)
+
+        //成功後重新發原請求
+        return apiClient(original)
+      } catch (refreshErr) {
+        //失敗強制登出
+        await authStore.logout(true)
+        return Promise.reject(refreshErr)
+      }
+    }
+    return Promise.reject(err)
   },
-})
+)

--- a/tarot-planning/src/router/index.js
+++ b/tarot-planning/src/router/index.js
@@ -121,24 +121,16 @@ const router = createRouter({
   ],
 })
 
-router.beforeEach(async (to, from, next) => {
+router.beforeEach(async (to) => {
   const authStore = useAuthStore()
 
-  try {
-    await authStore.refreshIfNeeded()
-  } catch (e) {
-    await authStore.logout()
-  }
-
   if (to.meta.guestOnly && authStore.isAuthenticated) {
-    return next({ name: 'today-draw' })
+    return { name: 'today-draw' }
   }
 
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
-    return next({ name: 'login' })
+    return { name: 'login' }
   }
-
-  next()
 })
 
 export default router

--- a/tarot-planning/src/stores/authStore.js
+++ b/tarot-planning/src/stores/authStore.js
@@ -2,13 +2,16 @@ import { defineStore } from 'pinia'
 import dayjs from 'dayjs'
 import { decodeExp } from '@/features/decodeJWT'
 import { ref, computed } from 'vue'
-import tarotDiaryAPI from '@/features/tarotDiaryAPI'
+import { useRouter } from 'vue-router'
+import { apiClient } from '@/lib/http'
 
 export const useAuthStore = defineStore('authStore', () => {
   const token = ref(localStorage.getItem('accessToken') || null)
 
+  const router = useRouter()
+
   const isAuthenticated = computed(() => {
-    return !!token.value && dayjs().isBefore(dayjs(decodeExp(token.value)))
+    return !!token.value
   })
 
   function setToken(newToken) {
@@ -16,26 +19,29 @@ export const useAuthStore = defineStore('authStore', () => {
     localStorage.setItem('accessToken', newToken)
   }
 
-  async function refreshIfNeeded() {
-    if (!token.value) return
-    try {
-      const newToken = await tarotDiaryAPI.refreshAccess(token.value)
-      setToken(newToken)
-    } catch (e) {
-      removeToken()
-      return
-    }
-  }
-
   function removeToken() {
     token.value = null
     localStorage.removeItem('accessToken')
   }
 
-  async function logout() {
-    await tarotDiaryAPI.POST('/api/auth/logout')
-    removeToken()
+  async function logout(force = false) {
+    try {
+      if (!force) {
+        await apiClient.post(
+          '/api/auth/refresh',
+          {},
+          {
+            headers: { Authorization: `Bearer ${token.value}` },
+          },
+        )
+      }
+    } catch (e) {
+      throw new Error(e)
+    } finally {
+      removeToken()
+      router.push({ name: 'login' })
+    }
   }
 
-  return { token, isAuthenticated, setToken, refreshIfNeeded, logout }
+  return { token, isAuthenticated, setToken, removeToken, logout }
 })


### PR DESCRIPTION
@CReticulata 
這個做得比較雜
先是將 tarotAPI 裡面的 refreshAccess、authStore 裡的 refreshIfNeeded 邏輯拿掉
改成在 response 的 interceptor 中判斷 401 失敗時嘗試 refresh，再失敗就強制登出
但是登出時的邏輯也出錯（有時 removeToken 有時打 logout api），所以將 removeToken 搬到 logout 裡