### PR TITLE
Feat/profile flow

### DIFF
--- a/tarot-planning/src/stores/profileStore.js
+++ b/tarot-planning/src/stores/profileStore.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import tarotDiaryAPI from '@/features/tarotDiaryAPI'
+import dayjs from 'dayjs'
 
 export const useProfileStore = defineStore('profileStore', () => {
   // fake data for testing
@@ -16,7 +17,7 @@ export const useProfileStore = defineStore('profileStore', () => {
       email,
       name,
       gender,
-      birth_date,
+      birth_date: dayjs(birth_date).format('YYYY-MM-DD'),
     }
   }
 

--- a/tarot-planning/src/stores/profileStore.js
+++ b/tarot-planning/src/stores/profileStore.js
@@ -1,23 +1,39 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import tarotDiaryAPI from '@/features/tarotDiaryAPI'
 
 export const useProfileStore = defineStore('profileStore', () => {
   // fake data for testing
-  const profile = ref({
-    email: '15t@example.com',
-    name: '邱蓋',
-    password: 'Pass1234',
-    gender: 'other',
-    birth_date: '1990-05-15',
-  })
+  const profile = ref(null)
 
-  function updateProfile(data) {
-    // 之後應該要改成從 API 回來的資料
-    profile.value = { ...profile.value, ...data }
+  async function getProfile() {
+    const { data } = await tarotDiaryAPI.GET('/api/user/me')
+    setProfile(data)
+  }
+
+  function setProfile({ email, name, gender, birth_date }) {
+    profile.value = {
+      email,
+      name,
+      gender,
+      birth_date,
+    }
+  }
+
+  async function updateProfile(payload) {
+    const { data } = await tarotDiaryAPI.PUT('/api/user/update', payload)
+    setProfile(data)
+  }
+
+  function clearProfile() {
+    profile.value = null
   }
 
   return {
     profile,
+    getProfile,
+    setProfile,
     updateProfile,
+    clearProfile,
   }
 })

--- a/tarot-planning/src/views/LoginView.vue
+++ b/tarot-planning/src/views/LoginView.vue
@@ -50,8 +50,8 @@ async function onSubmit() {
   try {
     const res = await tarotDiaryAPI.POST('/api/auth/login', payload)
     authStore.setToken(res.token)
-    const profile = await tarotDiaryAPI.GET('/api/user/me')
-    profileStore.updateProfile(profile.data)
+
+    await profileStore.getProfile()
 
     router.push({ name: 'diary-zone' })
   } catch (error) {

--- a/tarot-planning/src/views/ProfileView.vue
+++ b/tarot-planning/src/views/ProfileView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   requiredRule,
@@ -8,7 +8,6 @@ import {
   emailRule,
 } from '@/features/validateRules.js'
 import { useProfileStore } from '@/stores/profileStore.js'
-import tarotDiaryAPI from '@/features/tarotDiaryAPI'
 import InputBoxRadio from '@/components/InputBoxRadio.vue'
 import InputBox from '@/components/InputBox.vue'
 
@@ -16,10 +15,11 @@ const router = useRouter()
 const profileStore = useProfileStore()
 
 const newProfileData = ref({
-  name: profileStore.profile.name,
-  password: profileStore.profile.password,
-  gender: profileStore.profile.gender,
-  birth_date: profileStore.profile.birth_date,
+  email: '',
+  name: '',
+  gender: '',
+  birth_date: '',
+  password: '',
 })
 
 const passwordConfirm = ref('')
@@ -49,7 +49,7 @@ const genderOptions = ref([
 
 const birthdate = computed({
   get() {
-    return newProfileData.value.birth_date.split('-').join('/')
+    return newProfileData.value.birth_date?.split('-').join('/')
   },
   set(date) {
     newProfileData.value.birth_date = date.split('/').join('-')
@@ -69,15 +69,14 @@ function openDialog() {
 }
 
 async function onSubmit() {
-  console.log(newProfileData.value)
-
   const payload = newProfileData.value
 
   try {
-    const res = await tarotDiaryAPI.PUT('/api/auth/update', payload)
-    console.log(res)
+    await profileStore.updateProfile(payload)
+    newProfileData.value = profileStore.profile
 
-    profileStore.updateProfile(payload)
+    newProfileData.value.password = ''
+    passwordConfirm.value = ''
 
     isSuccess.value = true
     openDialog()
@@ -101,11 +100,14 @@ function onHide() {
 
 function onCancel() {
   newProfileData.value = {
+    email: profileStore.profile.email,
     name: profileStore.profile.name,
-    password: profileStore.profile.password,
+    password: '',
     gender: profileStore.profile.gender,
     birth_date: profileStore.profile.birth_date,
   }
+
+  passwordConfirm.value = ''
 
   isDisable.value = {
     email: true,
@@ -115,6 +117,16 @@ function onCancel() {
     birthdate: true,
   }
 }
+
+onMounted(async () => {
+  try {
+    await profileStore.getProfile()
+    newProfileData.value = { ...profileStore.profile, password: '' }
+  } catch (e) {
+    alert('資料獲取失敗' + e)
+    router.back()
+  }
+})
 </script>
 
 <template>
@@ -127,7 +139,7 @@ function onCancel() {
         <InputBox
           title="帳號"
           :hasSign="false"
-          v-model="profileStore.profile.email"
+          v-model="newProfileData.email"
           :rules="[emailRule]"
           :disable="isDisable.email"
         ></InputBox>

--- a/tarot-planning/src/views/register/RegisterView.vue
+++ b/tarot-planning/src/views/register/RegisterView.vue
@@ -72,7 +72,7 @@ async function onSubmit() {
     const res = await tarotDiaryAPI.POST('/api/auth/register', payload)
     console.log(res)
 
-    profileStore.updateProfile(payload)
+    profileStore.setProfile(payload)
 
     router.push({ name: 'registerConfirmation' })
   } catch (error) {


### PR DESCRIPTION
@CReticulata 
ca37842872efbc3df6930370e1bf081fa64dc3fa 重構 profileStore：替換假資料預設null，新增 get, update, clear 等function
01777e1f0ae95f8e48f6659d56a488ee3556bd10 登入時更新 profileStore
d346f4a98f0e60bf3a45aa8fa55b7002d735fc22 重構 ProfileView 編輯流程：欄位預設空字串，getProfile 後填入欄位，update 後也將新資料填入欄位，RegisterView 的 updateProfile 改成 setProfile
16cd5f4d1557aac8d994d4e28e597317cb2fad59 發現生日更新日期後會往回退一天，先用 dayjs.format 統一格式暫時解決

原本 Register 的 updateProfile 意思是將使用者註冊的資料填入 store 嗎？如果是我想改成 setProfile，updateProfile 就改成做 PUT 的動作，你覺得呢？